### PR TITLE
fix: use correct model

### DIFF
--- a/main.py
+++ b/main.py
@@ -146,7 +146,7 @@ class TradingAgent:
         self.urls = self.secret_client.get_urls(model=self.models[0])
         self.secret_ai_llm = ChatSecret(
             base_url=self.urls[0],
-            model='llama3.1:70b',
+            model=self.models[0],
             temperature=1.0
         )
         setup_database()


### PR DESCRIPTION
Ran into issue running the llama3.1:70b, change it to `models[0]` solves the issue.